### PR TITLE
Update impact-model-plugin spec to reflect learnings from JSII and Boavizta

### DIFF
--- a/specs/impact-model-plugin.md
+++ b/specs/impact-model-plugin.md
@@ -18,13 +18,15 @@ The goal of the Impact Measurement Plugin (IMP) Spec is to define a common stand
 
 ## Impact Model Interface Specification 
 
-The Impact Model Interface Specification project is here to standardise an interface to existing and future impact models (IMOs). The ecosystem of solutions we need for Impact measurement will sit on a solid bedrock of Impact Model Interfaces (IMIs) that have the same interface, to enable reusability, and comparability. 
+The Impact Model Interface Specification project is here to standardise an interface to existing and future impact measurement plugins (IMPs). 
+
+The ecosystem of solutions we need for Impact measurement will sit on a solid bedrock of Impact Model Plugins (IMPs) that expose the same interface, to enable reusability, and comparability. 
 
 Any class library that exposes the IMI interface adheres to this specification.
 
-The interface describes the bidirectional communication between an IMO and what's calling the IMO. It describes the function signature, the data types and the exceptions used to pass back information to the caller.
+The interface describes the bidirectional communication between an IMP and what's calling the IMP. It describes the function signature, the data types and the exceptions used to pass back information to the caller.
 
-This version of the specification does not pick any specific language, but it does assume the language has support for exception handling.
+This version of the specification does not pick any specific language, but it does assume the language is OO has support for exception handling.
 
 ## Data Types
 
@@ -32,11 +34,11 @@ This version of the specification does not pick any specific language, but it do
 
 This is a simple dictionary used to set up an IMM. Each IMM is different and can have a wide variety of parameters. The specification cannot define what these parameters will be, so we choose to have a simple data type of a dictionary which accepts all types and quantity of params.
 
-### Telemetry
+### Measuerment
 
-This is a unit of data to describe some inputs to an IMM. Since every IMM is different we can’t prescribe too much in the specification, however the only two fields that would be mandatory for each unit of telemetry is the date/time when the telemetry was gathered and the time-range for which the telemetry is for. For example, you might have some telemetry for CPU utilisation, but we also need to know when this telemetry was gathered and for what period of time does the telemetry measure.
+This is a unit of data to describe some inputs to an IMM. Since every IMM is different we can’t prescribe too much in the specification, however the only two fields that would be mandatory for each unit of measurement is the date/time when the measurement was gathered and the time-range for which the measurement is valid for. For example, you might have some measurement for CPU utilisation, but we also need to know when this measurement was gathered and for what period of time does the measurement span.
 
-Telemetry can be aggregate or granular, for example it might contain an average of cpu utilization across a range of machines.
+Measurement can be aggregate or granular, for example it might contain an average of cpu utilization across a range of machines.
 
 `{ “date-time”: xxxx, “duration”: xxx, “cpu-util”: 0.5 }`
 
@@ -48,25 +50,13 @@ Or it might contain even more granular data to the process level:
 
 `{ “date-time”: xxxx, “duration”: xxx, machines: { “gsf-001”: { processes: { “process-001”: “cpu-util”: 0.5 } }  }`
 
-This is just an example to demonstrate just how wide a variety of data there can be for Telemetry, there may be an infinite variety of inputs here. The Telemetry is really defined by the IMM, if the IMM does per processes modelling then the Telemetry can provide per process data.
-
-### TelemetryStream
-
-This data type returns a stream of Telemetry objects, used when we want to calculate impact metrics in real-time.
-
-### ImpactModel
-
-This datatype holds the instance for an IMO.
+This is just an example to demonstrate just how wide a variety of data there can be for measurements, there may be an infinite variety of inputs here. The measurement is really defined by the IMM, if the IMM does per processes modelling then the measurement can provide per process data.
 
 ### ImpactMetric
 
 This datatype holds the results of an IMM model call, the estimated energy, carbon, water values. It also might contain information about the calculation for debugging purposes.
 
-Whereas the Telemetry can vary wildly depending on IMM, we do need to normalise all ImpactMetrics into a common data type with a common structure. This will be an area of focus as we build out more IMPs using the spec.
-
-### ImpactMetricStream
-
-This data type returns a stream of ImpactMetrics to use in a real-time monitoring context.
+Whereas the Measurement can vary wildly depending on IMM, we do need to normalise all ImpactMetrics into a common data type with a common structure. This will be an area of focus as we build out more IMPs using the spec.
 
 ## Exceptions
 
@@ -79,20 +69,18 @@ This data type returns a stream of ImpactMetrics to use in a real-time monitorin
 
 ```ts
 interface ImpactModelInterface {
-  public static create(name: string, params: StaticParams): ImpactModelInterface
+  public configure(name: string, params: StaticParams): ImpactModelInterface
   public authenticate(authParams: AuthParams): void
-  public snapshot(telemetry: Telemetry): ImpactMetric
-  public batch(batchTelemetry: Array<Telemetry>): Array<ImpactMetric>
-  public stream(streamTelemetry: TelemetryStream): ImpactMetricStream
+  public calculate(measurements: Arrray<Measurement>): ImpactMetric
 }
 ```
 
-### Create
+### Configure
 
 #### Signature
 
 ```ts
-public static create(name: string, params: StaticParams): ImpactModelInterface
+public configure(name: string, params: StaticParams): ImpactModelInterface
 ```
 
 #### Example usage
@@ -100,15 +88,17 @@ public static create(name: string, params: StaticParams): ImpactModelInterface
 ```ts
 class ConcreteVM extends ImpactModelInterface { ... }
 
-let model = ConcreteVM.create("backend-server", {vendor: "GCP"});
+let model = new ConcreteVM().configure("backend-server", {vendor: "GCP"});
 ```
 
 #### Responsibilities
 
-* Instantiates an Impact Model which exposed the Impact Model Interface through a factory `create` function
+_Due to limitations of the JSII interface we cannot use static methods and factory patterns._
+
+* Configures an instantiated instance. 
 * Performs validation on any of the input static parameters. Each model is different,and will require a different set of input static params but at the same time we need each model to expose the same function signature. If you are passing incorrect params the model will inform you through
 * Performs any setup work for the model.
-* This step is necessary before any other function call in the spec..
+* This step is necessary before any other function call in the spec.
 * Return an instance to the Impact Model which holds any required state.
 
 #### Parameters
@@ -139,7 +129,7 @@ public authenticate(authParams: AuthParams): void
 
 ```ts
 class ConcreteVM extends ImpactModelInterface { ... }
-let model = ConcreteVM.create("backend-server", {vendor: "GCP"});
+let model = new ConcreteVM().configure("backend-server", {vendor: "GCP"});
 try {
     model.authenticate({username: "XXXX", password: "YYYY"})
 } catch AuthenticationError e {
@@ -175,16 +165,17 @@ This function estimates the emissions based on the telemetry provided for a sing
 #### Signature
 
 ```ts
-public snapshot(telemetry: Telemetry): ImpactMetric
+public calcualte(measure: Measurement): ImpactMetric
 ```
 
 #### Example usage
 
 ```ts
 class ConcreteVM extends ImpactModelInterface { ... }
-let model = ConcreteVM.create("backend-server", {vendor: "GCP"});
+let model = new ConcreteVM().configure("backend-server", {vendor: "GCP"});
 try {
-    let impact = model.snapshot({“date-time”: xxxx, “duration”: xxx, “cpu-util”: 0.5});
+    let measurement = {“date-time”: xxxx, “duration”: xxx, “cpu-util”: 0.5};
+    let impact = model.snapshot(measurement);
     console.log(impact);
 } catch {
     ...
@@ -193,13 +184,16 @@ try {
 
 #### Responsibilities
 
-* Checked that the telemetry has all the required fields for this model.
-* Performs what validations it can that the provided telemetry is not malformed.
-* Passes the telemetry to the underlying carbon model, executes the model and translates the response to match theEmissionsData data type.
+* Checked that the passed in measurements have all the required fields for this model.
+* Performs what validations it can that the provided measurements is not malformed.
+* Passes the measurements to the underlying carbon model, executes the model and translates the response to match the emissions data data type.
 
 #### Parameters
 
-* **telemetry** this is a dictionary of Telemetry. Each model can work with different types of telemetry, the spec cannot predict what types of telemetry will be used by all models so the telemetry is in the form of a Dict. 
+* **measures** 
+  * This is an array of measurements. 
+  * Each model can work with different types of inputs, the spec cannot predict what types of inputs will be used by all models so we need to keep this very open. 
+  * It's an array since we will (in the future) need to deal with GridEMissions (`I`) and that requires input data in a fine grain to make sure we map to `I` at the same granularity. E.g. we might want to output carbon per hour, but the input energy data is in 5min increments so we can make to the grid emissions in the same 5 min increments.
 
 
 #### Returns
@@ -212,124 +206,3 @@ An instance of an `ImpactMetric` which holds the estimate of emissions.
 * `MissingTelemetry`
 * `MalformedTelemetry`
 * `ExternalError`
-
-### Batch
-
-This function estimates the emissions for a batch of telemetry units, effectively the equivalent of calling a snapshot multiple times. The underlying implementation might be very different, however.
-
-You’d use this function once you’ve gathered some historical telemetry data from your system to see what the emissions of the systems were over that historical time period.
-
-This is the first step to simulating some options, once you have a baseline of emissions over that historical period, then you can ask “what if” questions, adjust the model and see how the emissions would have changed over that same historical period.
-
-
-#### Signature
-
-
-```ts
-public batch(batchTelemetry: Array<Telemetry>): Array<ImpactMetric>
-```
-
-#### Example usage
-
-```ts
-class ConcreteVM extends ImpactModelInterface { ... }
-let model = ConcreteVM.create("backend-server", {vendor: "GCP"});
-try {
-    let batchTelemetry = [
-        {“date-time”: xxxx, “duration”: xxx, “cpu-util”: 0.5},
-        {“date-time”: xxxx, “duration”: xxx, “cpu-util”: 0.2}
-        {“date-time”: xxxx, “duration”: xxx, “cpu-util”: 0.1}
-        {“date-time”: xxxx, “duration”: xxx, “cpu-util”: 0.93}
-    ];
-
-    let impacts = model.batch(batchTelemetry);
-
-    for (let impact of impacts) {
-        console.log(impact);
-    }
-    
-} catch {
-    ...
-}
-```
-
-#### Responsibilities
-
-* Checked that the array of telemetry has all the required fields for this model.
-* Performs what validations it can that the provided telemetry is not malformed.
-* Calls the underlying carbon model and for each passed input of telemetry outputs a similar unit of emissions data.
-
-
-#### Parameters
-
-* **batchTelemetry** is an array of Telemetry data types, each unit of telemetry here is for a single time range.
-
-#### Returns
-
-An array of `ImpactMetrics`, each instance matches 1 for 1 an instance of `Telemetry` passed in.
-
-#### Raises
-
-* `NotAuthorized`
-* `MissingTelemetry`
-* `MalformedTelemetry`
-* `ExternalError`
-
-
-### Stream
-
-This function calculates the emissions in realt-time for a stream of telemetry which is being passed in.
-
-Typically, this function would be used to monitor the emissions using the model in real-time. The input stream of telemetry would need to be sourced from some system, e.g. prometheus, a collector, agent, platform of some form. 
-
-The output ImpactMetricStream you might connect to the next step in the pipeline and send the emissions data somewhere to be processed by the next step, for example perhaps an alerting system to alert when the carbon emissions exceed a particular threshold.
-
-
-#### Signature
-
-
-```ts
-public stream(streamTelemetry: TelemetryStream): ImpactMetricStream
-```
-
-#### Example usage
-
-```ts
-class ConcreteVM extends ImpactModelInterface { ... }
-let model = ConcreteVM.create("backend-server", {vendor: "GCP"});
-try {
-    // Some form of stream reader which reads utilization live from GCP monitoring system- and streams back to us
-    let streamTelemetry = new GCPTelemetryReader("backend-server", ... );
-
-    let impactStream = model.stream(streamTelemetry);
-
-    let impact: ImpactMetric;
-    while (impact = impactStream.read()) {
-        console.log(impact)
-    }    
-} catch {
-    ...
-}
-```
-
-#### Responsibilities
-
-* Checks each Telemetry object has all the required fields.
-* Performs what validations it can that the provided telemetry is not malformed.
-* Reads from the stream object, and for every new object it calls effectively the snapshot function and returns in the response stream.
-
-#### Parameters
-
-* **streamTelemetry **is an object that returns a Telemetry object from a stream.
-
-#### Returns
-
-An instance of `ImpactMetricStream`.
-
-#### Raises
-
-* `NotAuthorized`
-* `MissingTelemetry`
-* `MalformedTelemetry`
-* `ExternalError`
-

--- a/specs/impact-model-plugin.md
+++ b/specs/impact-model-plugin.md
@@ -34,11 +34,13 @@ This version of the specification does not pick any specific language, but it do
 
 This is a simple dictionary used to set up an IMM. Each IMM is different and can have a wide variety of parameters. The specification cannot define what these parameters will be, so we choose to have a simple data type of a dictionary which accepts all types and quantity of params.
 
-### Measuerment
+### Observation
 
-This is a unit of data to describe some inputs to an IMM. Since every IMM is different we can’t prescribe too much in the specification, however the only two fields that would be mandatory for each unit of measurement is the date/time when the measurement was gathered and the time-range for which the measurement is valid for. For example, you might have some measurement for CPU utilisation, but we also need to know when this measurement was gathered and for what period of time does the measurement span.
+- An observation is a unit of data to describe some inputs to an IMM. 
+- Since every IMM is different we can’t prescribe too much in the specification, however the only two fields that would be mandatory for each observation is the date/time when the measurement was gathered and the duration for which the observation is valid for. 
+- For example, you might have some observation for CPU utilisation, but we also need to know when this observation was gathered and for what period of time does the observation span.
 
-Measurement can be aggregate or granular, for example it might contain an average of cpu utilization across a range of machines.
+An observation can be aggregate or granular, for example it might contain an average of cpu utilization across a range of machines.
 
 `{ “date-time”: xxxx, “duration”: xxx, “cpu-util”: 0.5 }`
 
@@ -50,7 +52,7 @@ Or it might contain even more granular data to the process level:
 
 `{ “date-time”: xxxx, “duration”: xxx, machines: { “gsf-001”: { processes: { “process-001”: “cpu-util”: 0.5 } }  }`
 
-This is just an example to demonstrate just how wide a variety of data there can be for measurements, there may be an infinite variety of inputs here. The measurement is really defined by the IMM, if the IMM does per processes modelling then the measurement can provide per process data.
+This is just an example to demonstrate just how wide a variety of data there can be for observations, there may be an infinite variety of inputs here. The observation is really defined by the IMM, if the IMM does per processes modelling then the observation can provide per process data.
 
 ### ImpactMetric
 
@@ -71,7 +73,7 @@ Whereas the Measurement can vary wildly depending on IMM, we do need to normalis
 interface ImpactModelInterface {
   public configure(name: string, params: StaticParams): ImpactModelInterface
   public authenticate(authParams: AuthParams): void
-  public calculate(measurements: Arrray<Measurement>): ImpactMetric
+  public calculate(observations: Arrray<Observation>): ImpactMetric
 }
 ```
 
@@ -165,7 +167,7 @@ This function estimates the emissions based on the telemetry provided for a sing
 #### Signature
 
 ```ts
-public calcualte(measure: Measurement): ImpactMetric
+public calcualte(observations: Array<Observation>): ImpactMetric
 ```
 
 #### Example usage
@@ -174,8 +176,8 @@ public calcualte(measure: Measurement): ImpactMetric
 class ConcreteVM extends ImpactModelInterface { ... }
 let model = new ConcreteVM().configure("backend-server", {vendor: "GCP"});
 try {
-    let measurement = {“date-time”: xxxx, “duration”: xxx, “cpu-util”: 0.5};
-    let impact = model.snapshot(measurement);
+    let observation = {“date-time”: xxxx, “duration”: xxx, “cpu-util”: 0.5};
+    let impact = model.calculate([observation]);
     console.log(impact);
 } catch {
     ...
@@ -184,14 +186,14 @@ try {
 
 #### Responsibilities
 
-* Checked that the passed in measurements have all the required fields for this model.
-* Performs what validations it can that the provided measurements is not malformed.
-* Passes the measurements to the underlying carbon model, executes the model and translates the response to match the emissions data data type.
+* Checked that the passed in observations have all the required fields for this model.
+* Performs what validations it can that the provided observations is not malformed.
+* Passes the observations to the underlying carbon model, executes the model and translates the response to match the emissions data data type.
 
 #### Parameters
 
 * **measures** 
-  * This is an array of measurements. 
+  * This is an array of observations. 
   * Each model can work with different types of inputs, the spec cannot predict what types of inputs will be used by all models so we need to keep this very open. 
   * It's an array since we will (in the future) need to deal with GridEMissions (`I`) and that requires input data in a fine grain to make sure we map to `I` at the same granularity. E.g. we might want to output carbon per hour, but the input energy data is in 5min increments so we can make to the grid emissions in the same 5 min increments.
 


### PR DESCRIPTION
Update the spec according to the findings in this issue https://github.com/Green-Software-Foundation/carbon-ql/issues/43 which investigated implementing the spec with Boavizta and JSII


1. Remove stream this is a feature of the thing that "calls" the plugin and the specific implementation will vary based on language/tech (e.g. threads, events). To stream this you just call calculate whenever your streaming implementation needs to.
2. Remove batch, this needs much more thought as per last project call (re: time, bucketing, synchronization), see https://github.com/Green-Software-Foundation/carbon-ql/issues/59
3. Update create -> configure, as per the learnings from #43 that we can't use the factory pattern.