### PR TITLE
Update yaml to reflect spec update

### DIFF
--- a/specs/impact-yaml.md
+++ b/specs/impact-yaml.md
@@ -42,14 +42,15 @@ components: # The nodes under this root node
       path: <a unique string, path to represent an IMP>
     config: # common static params
       <key>: <value>
-    measurement: # A single measurement
+    observation: # A set of data points for a moment and duration of time.
       <key>: <value>
       ...
-    measurements: # A series of measurements
+    observations: # Multiple sets of data points for multiples moments and durations of time.
       shared:
         <key>: <value> # Data that is repeated for every measurement, e.g machine type.
-      series: 
-    measurements: # A series of measurements stored in a CSV file
+      series:
+        - <first observation>
+    observations: # Observations stored in a CSV file
       path: <file> # Path to a CSV file containing the measurements
     components: # The sub nodes of this node
       - <name>: <another component same as above>
@@ -73,18 +74,10 @@ components:
       config: 
         vendor: gcp
         region: west-us
-      measurements:
-        shared: ~
-        data:
-          - 2023-07-06T00:00:
-            duration: 5s
-            cpu: 0.34
-          - 2023-07-06T00:05:
-            duration: 5s
-            cpu: 0.23
-          - 2023-07-06T00:05:
-            duration: 5s
-            cpu: 0.11
+      observation:
+        2023-07-06T00:00:
+        duration: 15s
+        cpu: 0.34
       components: ~ 
   - backend server:
       model: 
@@ -92,10 +85,10 @@ components:
       params: 
         vendor: azure
         region: east-us
-      measurements: 
+      observations: 
         shared:
           sku: AC2
-        data:
+        series:
           - 2023-07-06T00:00:
             duration: 5s
             cpu: 0.34
@@ -112,10 +105,10 @@ components:
       params: 
         vendor: aws
         region: france
-      measurements: 
+      observations: 
         shared:
           sku: EC2
-        data:      
+        series:      
           - 2023-07-06T00:00:
             duration: 5s
             cpu: 0.34

--- a/specs/impact-yaml.md
+++ b/specs/impact-yaml.md
@@ -75,7 +75,7 @@ components:
         vendor: gcp
         region: west-us
       observation:
-        2023-07-06T00:00:
+        datetime: 2023-07-06T00:00
         duration: 15s
         cpu: 0.34
       components: ~ 
@@ -89,13 +89,13 @@ components:
         shared:
           sku: AC2
         series:
-          - 2023-07-06T00:00:
+          - datetime: 2023-07-06T00:00
             duration: 5s
             cpu: 0.34
-          - 2023-07-06T00:05:
+          - datetime: 2023-07-06T00:05
             duration: 5s
             cpu: 0.23
-          - 2023-07-06T00:05:
+          - datetime: 2023-07-06T00:05:
             duration: 5s
             cpu: 0.11
       components: ~ 
@@ -109,13 +109,13 @@ components:
         shared:
           sku: EC2
         series:      
-          - 2023-07-06T00:00:
+          - datetime: 2023-07-06T00:00
             duration: 5s
             cpu: 0.34
-          - 2023-07-06T00:05:
+          - datetime: 2023-07-06T00:05
             duration: 5s
             cpu: 0.23
-          - 2023-07-06T00:05:
+          - datetime: 2023-07-06T00:05
             duration: 5s
             cpu: 0.11
       components: ~

--- a/specs/impact-yaml.md
+++ b/specs/impact-yaml.md
@@ -33,19 +33,26 @@ There are several use cases for an IMPL file.
 
 ```yaml
 name: <name> # The name of the root node (the applicatio as a whole)
+description: <description>
+tags:
+  <key>: <value>
 components: # The nodes under this root node
-  <name>: # The name of this node
-    params: # common static params
-      <key>: <value>
+  - <name>: # The name of this node
     model: # so we know which IMP to use to calculate this node
       path: <a unique string, path to represent an IMP>
-      params:
-        <key>: <value>
-    telemetry: # for more complex use cases can point to a CSV file
-      # Either a path to a CSV file
-      # Or you can add simple telemety inline in the YAML
-      components: # The sub nodes of this node
-        <name>: <another component same as above>
+    config: # common static params
+      <key>: <value>
+    measurement: # A single measurement
+      <key>: <value>
+      ...
+    measurements: # A series of measurements
+      shared:
+        <key>: <value> # Data that is repeated for every measurement, e.g machine type.
+      series: 
+    measurements: # A series of measurements stored in a CSV file
+      path: <file> # Path to a CSV file containing the measurements
+    components: # The sub nodes of this node
+      - <name>: <another component same as above>
 ```
 
 ## Example
@@ -54,63 +61,71 @@ A simple 3 component web server application running on GCP, Azure and AWS and us
 
 ```yaml
 name: My application
+description: A simple web server
+tags:
+  kind: web-server
+  complexity: simple
+  category: cloud
 components:
-  load balencer: 
-    params: 
-      vendor: gcp
-      region: west-us
-    model: 
-      path: org.boavizta.imp.vm.sci
-      params: ~
-    telemetry: 
-      - 2023-07-06T00:00:
-        duration: 5s
-        cpu: 0.34
-      - 2023-07-06T00:05:
-        duration: 5s
-        cpu: 0.23
-      - 2023-07-06T00:05:
-        duration: 5s
-        cpu: 0.11
-    components: ~ 
-  backend server:
-    params: 
-      vendor: azure
-      region: east-us
-    model: 
-      path: org.boavizta.imp.vm.sci
-      params:
-        sku: AC2
-    telemetry: 
-      - 2023-07-06T00:00:
-        duration: 5s
-        cpu: 0.34
-      - 2023-07-06T00:05:
-        duration: 5s
-        cpu: 0.23
-      - 2023-07-06T00:05:
-        duration: 5s
-        cpu: 0.11
-    components: ~ 
-  caching layer:
-    params: 
-      vendor: aws
-      region: france
-    model: 
-      path: com.intel.imp.vm.sci
-      params:
-        sku: EC2
-    telemetry: 
-      - 2023-07-06T00:00:
-        duration: 5s
-        cpu: 0.34
-      - 2023-07-06T00:05:
-        duration: 5s
-        cpu: 0.23
-      - 2023-07-06T00:05:
-        duration: 5s
-        cpu: 0.11
-    components: ~
+  - load balencer: 
+      model: 
+        path: org.boavizta.imp.vm.sci  
+      config: 
+        vendor: gcp
+        region: west-us
+      measurements:
+        shared: ~
+        data:
+          - 2023-07-06T00:00:
+            duration: 5s
+            cpu: 0.34
+          - 2023-07-06T00:05:
+            duration: 5s
+            cpu: 0.23
+          - 2023-07-06T00:05:
+            duration: 5s
+            cpu: 0.11
+      components: ~ 
+  - backend server:
+      model: 
+        path: org.boavizta.imp.vm.sci  
+      params: 
+        vendor: azure
+        region: east-us
+      measurements: 
+        shared:
+          sku: AC2
+        data:
+          - 2023-07-06T00:00:
+            duration: 5s
+            cpu: 0.34
+          - 2023-07-06T00:05:
+            duration: 5s
+            cpu: 0.23
+          - 2023-07-06T00:05:
+            duration: 5s
+            cpu: 0.11
+      components: ~ 
+  - caching layer:
+      model: 
+        path: com.intel.imp.vm.sci  
+      params: 
+        vendor: aws
+        region: france
+      measurements: 
+        shared:
+          sku: EC2
+        data:      
+          - 2023-07-06T00:00:
+            duration: 5s
+            cpu: 0.34
+          - 2023-07-06T00:05:
+            duration: 5s
+            cpu: 0.23
+          - 2023-07-06T00:05:
+            duration: 5s
+            cpu: 0.11
+      components: ~
 ```
 
 Once it's run trhough `impcon` it might return/print out a yaml like so which contains the core aspects of an SCI score.
@@ -124,13 +139,13 @@ name: My application
 e: 63 mWh # sum of all the child node energy 
 m: 61g # sum of all the child node embodied
 components:
-  load balencer: 
+  - load balencer: 
     e: 48 mWh
     m: 4g
-  backend server:
+  - backend server:
     e: 5 mWh
     m: 23g
-  caching layer:
+  - caching layer:
     e: 10 mWh
     m: 34g
 ```
@@ -154,15 +169,15 @@ scope1: 10.9g # sum of all the child node scope 1
 scope2: 95g # sum of all the child node scope 2
 scope3: 162g # sum of all the child node scope 3
 components:
-  load balencer: 
+  - load balencer: 
     scope1: 1.2g 
     scope2: 17g
     scope3: 56g
-  backend server:
+  - backend server:
     scope1: 2.3g 
     scope2: 28g
     scope3: 18g
-  caching layer:
+  - caching layer:
     scope1: 7.4g 
     scope2: 33g
     scope3: 88g

--- a/specs/impact-yaml.md
+++ b/specs/impact-yaml.md
@@ -50,6 +50,10 @@ components: # The nodes under this root node
         <key>: <value> # Data that is repeated for every measurement, e.g machine type.
       series:
         - <first observation>
+      mapping: # map the obversations into the format this model requires
+        <key>: # the key in the observation data (e.g. cpu, duration)
+          units: <unit> # what units this field is in, e.g. percentage, hours, secs
+          to: <to-key> # tranform the input <key> into <to-key>, e.g. transform "span" into "duration"
     observations: # Observations stored in a CSV file
       path: <file> # Path to a CSV file containing the measurements
     components: # The sub nodes of this node
@@ -74,9 +78,9 @@ components:
       config: 
         vendor: gcp
         region: west-us
-      observation:
+      observation: # a single observation for the whole duration
         datetime: 2023-07-06T00:00
-        duration: 15s
+        duration: 15
         cpu: 0.34
       components: ~ 
   - backend server:
@@ -90,14 +94,18 @@ components:
           sku: AC2
         series:
           - datetime: 2023-07-06T00:00
-            duration: 5s
+            span: 5 # this data is using span, but the model expects duration
             cpu: 0.34
           - datetime: 2023-07-06T00:05
-            duration: 5s
+            span: 5
             cpu: 0.23
           - datetime: 2023-07-06T00:05:
-            duration: 5s
+            span: 5
             cpu: 0.11
+        mapping:
+          span:
+            units: seconds
+            to: duration
       components: ~ 
   - caching layer:
       model: 


### PR DESCRIPTION
Updated the YAML spec to include learnings from 
https://github.com/Green-Software-Foundation/carbon-ql/pull/62
and 
https://github.com/Green-Software-Foundation/carbon-ql/pull/60

1. Added tags
2. Added clarity re: loading from CSV file.
3. Name change from telemetry -> observations to reflect that we are not consuming "raw" telemetry which is getting people in the SRE/DevOps space confused. We'll be inputting some already pre-aggregated measures, smallest duration will likely be 5 mins to match to the smallest duration of grid emissions data it's possible to gather. This isn't millisecond telemetry. In other contexts, e.g. time series data, a term for this is an observation.
4. Cleaned up re: use of arrays to list the components.